### PR TITLE
Fix: Ensure panel close button is always visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,6 +92,12 @@ body {
     font-size: 16px;
 }
 
+.panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 .add-card-btn {
     border: none;
     background-color: #42b72a;


### PR DESCRIPTION
The panel's close/delete button was being created correctly in JavaScript but was not always visible in the UI. This was likely caused by its container, `.panel-actions`, lacking specific layout styles, leading to inconsistent rendering within the panel header's flexbox layout.

This change adds `display: flex` and related alignment properties to the `.panel-actions` CSS class. This ensures the container and its contents (the close button) are laid out correctly and remain visible on all panels.