### PR TITLE
Fix: Repair broken drag-and-drop for panels and cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,6 +92,12 @@ body {
     font-size: 16px;
 }
 
+.panel-actions {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 .add-card-btn {
     border: none;
     background-color: #42b72a;

--- a/js/main.js
+++ b/js/main.js
@@ -115,14 +115,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Panel Drag and Drop ---
     panelsContainer.addEventListener('dragstart', e => {
-        const handle = e.target.closest('.drag-handle');
-        // Only allow dragging from the handle
-        if (!handle) {
-            e.preventDefault();
-            return;
+        // This listener is on the container to handle panel dragging.
+        // It must NOT interfere with drag events from children (e.g., cards).
+        // We only act if the drag's target is a .panel element itself.
+        if (!e.target.classList.contains('panel')) {
+            return; // Exit for card drags, etc.
         }
 
-        const panel = e.target.closest('.panel');
+        const panel = e.target; // The target is the panel itself
+
         // Use a timeout to avoid visual glitches when the class is added
         setTimeout(() => {
             panel.classList.add('dragging');


### PR DESCRIPTION
A single flawed `dragstart` event listener on the `panelsContainer` was the root cause for both panel and card drag-and-drop failures.

The listener incorrectly intercepted and cancelled `dragstart` events that bubbled up from child elements (like cards). It also contained flawed logic for initiating panel drags.

This commit refactors the listener to only act on `dragstart` events where the target is a `.panel` element. This allows panel dragging to work correctly while no longer interfering with card dragging. A comment has been added to clarify this logic.