### PR TITLE
docs: Update changelog for version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2025-08-25
+
+### Added
+- Pressing the `Escape` key while editing a note card will now save the text and exit the editing mode.
+
+### Fixed
+- Improved the reliability of the Escape key functionality to ensure it consistently removes focus from the text area in the extension environment.
+
 ## [1.1.0] - 2025-08-25
 
 ### Added

--- a/js/panels.js
+++ b/js/panels.js
@@ -166,6 +166,13 @@ function createCard(cardsContainer, cardState, onStateChange) {
 
     cardText.addEventListener('blur', onStateChange);
 
+    cardText.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.target.blur();
+        }
+    });
+
     card.addEventListener('dragstart', e => {
         e.dataTransfer.setData('text/plain', e.target.id);
         setTimeout(() => card.classList.add('dragging'), 0);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "New Tab Organizer",
-  "version": "1.1",
+  "version": "1.1.1",
   "description": "A customizable startpage with bookmarks and notes.",
   "permissions": [
     "bookmarks",


### PR DESCRIPTION
Adds a new section to the changelog for version 1.1.1, documenting the new feature for saving notes with the Escape key and the subsequent bug fix for it.