### PR TITLE
Fix(bookmarks): Open bookmark links in a new tab

### DIFF
--- a/js/mainB.js
+++ b/js/mainB.js
@@ -437,6 +437,10 @@ function renderBookmarks(element, bookmarks, folderId, refreshCallback) {
             link.href = bookmark.url;
             link.textContent = bookmark.title;
             link.className = 'bookmark-link';
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: link.href });
+            });
             item.appendChild(link);
 
             const actions = document.createElement('div');

--- a/js/mainC.js
+++ b/js/mainC.js
@@ -437,6 +437,10 @@ function renderBookmarks(element, bookmarks, folderId, refreshCallback) {
             link.href = bookmark.url;
             link.textContent = bookmark.title;
             link.className = 'bookmark-link';
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: link.href });
+            });
             item.appendChild(link);
 
             const actions = document.createElement('div');


### PR DESCRIPTION
The bookmark links on tabs 2 and 3 were not working for certain websites (e.g., Gmail) due to browser security restrictions on extensions. Additionally, the tab title would not update upon navigation.

This was because the links were standard `<a>` tags trying to navigate within an iframe on an extension page.

This commit fixes the issue by adding a click event listener to all bookmark links. This listener prevents the default navigation and instead uses the `chrome.tabs.create()` API to open the bookmark's URL in a new tab. This ensures that all links open correctly and that the new tab displays the proper title of the opened page.

The fix has been applied to both `js/mainB.js` and `js/mainC.js` to resolve the issue on both tab 2 and tab 3.