### PR TITLE
Fix(bookmarks): Apply bookmark fix to startpage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -437,6 +437,10 @@ function renderBookmarks(element, bookmarks, folderId, refreshCallback) {
             link.href = bookmark.url;
             link.textContent = bookmark.title;
             link.className = 'bookmark-link';
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: link.href });
+            });
             item.appendChild(link);
 
             const actions = document.createElement('div');

--- a/js/mainB.js
+++ b/js/mainB.js
@@ -437,6 +437,10 @@ function renderBookmarks(element, bookmarks, folderId, refreshCallback) {
             link.href = bookmark.url;
             link.textContent = bookmark.title;
             link.className = 'bookmark-link';
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: link.href });
+            });
             item.appendChild(link);
 
             const actions = document.createElement('div');

--- a/js/mainC.js
+++ b/js/mainC.js
@@ -437,6 +437,10 @@ function renderBookmarks(element, bookmarks, folderId, refreshCallback) {
             link.href = bookmark.url;
             link.textContent = bookmark.title;
             link.className = 'bookmark-link';
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: link.href });
+            });
             item.appendChild(link);
 
             const actions = document.createElement('div');


### PR DESCRIPTION
This commit applies the same fix from the previous commit (opening bookmarks in a new tab using `chrome.tabs.create()`) to `js/main.js`, which controls the first tab (`startpage.html`).

This ensures that bookmark links work reliably across all three organizer tabs.